### PR TITLE
check for remote addr

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -293,7 +293,7 @@ function firewall()
 	if (FIREWALL_ON == TRUE) {
 
 		// Allow only access from whitelisted IP addresses
-		if (! in_array($_SERVER['REMOTE_ADDR'], ALLOWED_IP_ADDR)) {
+		if (isset($_SERVER['REMOTE_ADDR']) && !in_array($_SERVER['REMOTE_ADDR'], ALLOWED_IP_ADDR)) {
 
 			header($_SERVER["SERVER_PROTOCOL"]." 403 Forbidden");
 			exit('<p>You are not allowed to access the application using your IP address.</p>');


### PR DESCRIPTION
Should check for $_SERVER['REMOTE_ADDR'] to be set before accessing it.

PR made at request in https://github.com/the-benchmarker/web-frameworks/pull/2425